### PR TITLE
fixed crashing of kalmia due to not invalid file path in Windows 11

### DIFF
--- a/embedded/embedded.go
+++ b/embedded/embedded.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -56,24 +57,24 @@ func CopyEmbeddedFile(path string, to string) error {
 	return err
 }
 
-func CopyEmbeddedFolder(path string, to string) error {
-	dir := filepath.Join("rspress", path)
+func CopyEmbeddedFolder(currentPath string, to string) error {
+	dir := path.Join("rspress", currentPath)
 	entries, err := RspressFS.ReadDir(dir)
 	if err != nil {
 		return err
 	}
 
 	for _, entry := range entries {
-		destPath := filepath.Join(to, entry.Name())
+		destPath := path.Join(to, entry.Name())
 		if entry.IsDir() {
 			if err := os.MkdirAll(destPath, 0755); err != nil {
 				return err
 			}
-			if err := CopyEmbeddedFolder(filepath.Join(path, entry.Name()), destPath); err != nil {
+			if err := CopyEmbeddedFolder(path.Join(currentPath, entry.Name()), destPath); err != nil {
 				return err
 			}
 		} else {
-			if err := CopyEmbeddedFile(filepath.Join(path, entry.Name()), destPath); err != nil {
+			if err := CopyEmbeddedFile(path.Join(currentPath, entry.Name()), destPath); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This is in regard to this issue: [#19](https://github.com/DifuseHQ/Kalmia/issues/19)

As Windows uses forward slashes '\' for their file separators, and in Go filepath.Join uses OS specific separator and it's found to be a bug in Go embed that in Windows it's not able to detect the forward slash paths.
It's been discussed in official Go language repo: [#45230](https://github.com/golang/go/issues/45230)
This PR fixes that issue by using path.Join instead to traverse folders and directories and it works on both Unix and Windows.