### PR TITLE
Local file upload

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -4,6 +4,7 @@
   "database": "postgres://user:password@postgres:5432/kalmia?sslmode=disable",
   "logLevel": "debug",
   "assetStorage": "local",
+  "maxFileSize": 10,
   "sessionSecret": "thisisaverysecretkeyhasalotoflengthandeverything!",
   "users": [
     {

--- a/config.example.json
+++ b/config.example.json
@@ -3,6 +3,7 @@
   "port": 2727,
   "database": "postgres://user:password@postgres:5432/kalmia?sslmode=disable",
   "logLevel": "debug",
+  "assetStorage": "local",
   "sessionSecret": "thisisaverysecretkeyhasalotoflengthandeverything!",
   "users": [
     {

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	Database       string         `json:"database"`
 	LogLevel       string         `json:"logLevel"`
 	AssetStorage   string         `json:"assetStorage"`
+	MaxFileSize    int64          `json:"maxFileSize"` // in MB
 	SessionSecret  string         `json:"sessionSecret"`
 	Admins         []User         `json:"users"`
 	DataPath       string         `json:"dataPath"`
@@ -79,6 +80,11 @@ func ParseConfig(path string) *Config {
 
 	if err != nil {
 		panic(err)
+	}
+	// INFO: Adds the default max file size of 10
+	// Added for backwards compatibility
+	if ParsedConfig.MaxFileSize == 0 {
+		ParsedConfig.MaxFileSize = 10
 	}
 
 	return ParsedConfig

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	Port           int            `json:"port"`
 	Database       string         `json:"database"`
 	LogLevel       string         `json:"logLevel"`
+	AssetStorage   string         `json:"assetStorage"`
 	SessionSecret  string         `json:"sessionSecret"`
 	Admins         []User         `json:"users"`
 	DataPath       string         `json:"dataPath"`

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -146,20 +146,22 @@ func GetUser(authService *services.AuthService, w http.ResponseWriter, r *http.R
 }
 
 func UploadFile(db *gorm.DB, w http.ResponseWriter, r *http.Request, cfg *config.Config) {
-	err := r.ParseMultipartForm(10 << 20)
+	// Capped at MaxFileSize set by the user
+	err := r.ParseMultipartForm(cfg.MaxFileSize << 20)
 	if err != nil {
 		SendJSONResponse(http.StatusBadRequest, w, map[string]string{"status": "error", "message": "failed_to_parse_form"})
 		return
 	}
 
 	file, header, err := r.FormFile("upload")
+
 	if err != nil {
 		SendJSONResponse(http.StatusBadRequest, w, map[string]string{"status": "error", "message": "failed_to_get_file"})
 		return
 	}
 	defer file.Close()
 
-	if header.Size > 10<<20 {
+	if header.Size > cfg.MaxFileSize<<20 {
 		SendJSONResponse(http.StatusBadRequest, w, map[string]string{"status": "error", "message": "file_too_large"})
 		return
 	}

--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"git.difuse.io/Difuse/kalmia/config"
 	"git.difuse.io/Difuse/kalmia/services"
@@ -17,6 +18,7 @@ import (
 	"golang.org/x/oauth2/microsoft"
 	"gorm.io/gorm"
 
+	"github.com/gabriel-vasile/mimetype"
 	githubClient "github.com/google/go-github/v39/github"
 )
 
@@ -170,10 +172,30 @@ func UploadFile(db *gorm.DB, w http.ResponseWriter, r *http.Request, cfg *config
 
 	contentType := http.DetectContentType(fileBytes)
 
-	fileURL, err := services.UploadToStorage(bytes.NewReader(fileBytes), header.Filename, contentType, cfg)
+	fmt.Println("Request URI: ", r.RequestURI)
+	reqUrl, err := url.ParseRequestURI(r.Referer())
 	if err != nil {
-		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": "failed_to_upload_file"})
-		return
+		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": "failed_to_upload_file\nERROR: Invalid referrer URI"})
+	}
+	urlQuery := reqUrl.Query()
+	fileData := services.UploadedFileData{
+		OriginalName:  header.Filename,
+		MimeType:      mimetype.Detect(fileBytes),
+		DocId:         urlQuery.Get("id"),
+		PageId:        urlQuery.Get("pageId"),
+		VersionId:     urlQuery.Get("versionId"),
+		VersionNumber: urlQuery.Get("version"),
+	}
+	var fileURL string
+
+	if cfg.AssetStorage == "local" {
+		fileURL, err = services.SaveToLocal(fileBytes, &fileData)
+	} else {
+		fileURL, err = services.UploadToS3Storage(bytes.NewReader(fileBytes), header.Filename, contentType, cfg)
+		if err != nil {
+			SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": "failed_to_upload_file"})
+			return
+		}
 	}
 
 	SendJSONResponse(http.StatusOK, w, map[string]string{"status": "success", "message": "file_uploaded", "file": fileURL})

--- a/handlers/file.go
+++ b/handlers/file.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"net/http"
+	"os"
+	"path"
+
+	"git.difuse.io/Difuse/kalmia/config"
+	"git.difuse.io/Difuse/kalmia/services"
+	"gorm.io/gorm"
+)
+
+func GetFile(service *gorm.DB, w http.ResponseWriter, r *http.Request, cfg *config.Config) {
+	q := r.URL.Query()
+	fileData := services.UploadedFileData{
+		OriginalName:  q.Get("name"),
+		DocId:         q.Get("id"),
+		PageId:        q.Get("pageId"),
+		VersionId:     q.Get("versionId"),
+		VersionNumber: q.Get("version"),
+	}
+	dataPath := config.ParsedConfig.DataPath
+
+	generatedFilePath := generateFilePath(&fileData, dataPath)
+
+	_, err := os.Open(generatedFilePath)
+	if err != nil {
+		SendJSONResponse(http.StatusNotFound, w, map[string]string{"status": "error", "message": "File not found: " + err.Error()})
+		return
+	}
+
+	http.ServeFile(w, r, generatedFilePath)
+}
+
+func generateFilePath(fileData *services.UploadedFileData, dataPath string) string {
+	return path.Join(
+		dataPath,
+		"rspress_data",
+		"doc_"+fileData.DocId,
+		"assets",
+		fileData.OriginalName)
+}

--- a/main.go
+++ b/main.go
@@ -61,6 +61,11 @@ func main() {
 	r := mux.NewRouter()
 	kRouter := r.PathPrefix("/kal-api").Subrouter()
 
+	// INFO: files could be fetched without authentication
+	fileRouter := kRouter.PathPrefix("/file").Subrouter()
+
+	fileRouter.HandleFunc("/get", func(w http.ResponseWriter, r *http.Request) { handlers.GetFile(d, w, r, config.ParsedConfig) }).Methods("GET")
+
 	/* Health endpoints */
 	healthRouter := kRouter.PathPrefix("/health").Subrouter()
 	healthRouter.HandleFunc("/ping", handlers.HealthPing).Methods("GET")

--- a/services/docs_import.go
+++ b/services/docs_import.go
@@ -61,7 +61,7 @@ func processMarkdown(content, dir string, cfg *config.Config) (string, error) {
 
 			mime := utils.GetContentType(absPath)
 
-			s3URL, err := UploadToStorage(file, filepath.Base(absPath), mime, cfg)
+			s3URL, err := UploadToS3Storage(file, filepath.Base(absPath), mime, cfg)
 			if err != nil {
 				return
 			}

--- a/services/s3.go
+++ b/services/s3.go
@@ -16,7 +16,8 @@ import (
 	"github.com/gabriel-vasile/mimetype"
 )
 
-func UploadToStorage(file io.Reader, originalFilename, contentType string, parsedConfig *config.Config) (string, error) {
+// TODO: update the parameters to accept services.UploadedFileData{}
+func UploadToS3Storage(file io.Reader, originalFilename, contentType string, parsedConfig *config.Config) (string, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Endpoint:         aws.String(parsedConfig.S3.Endpoint),
 		Region:           aws.String(parsedConfig.S3.Region),
@@ -36,6 +37,7 @@ func UploadToStorage(file io.Reader, originalFilename, contentType string, parse
 
 	ext := filepath.Ext(originalFilename)
 	if ext == "" {
+		// TODO: update this part to detect mimetype once on UploadFile()
 		detectedMIME := mimetype.Detect(fileBytes)
 		ext = detectedMIME.Extension()
 		if contentType == "" {

--- a/services/s3_test.go
+++ b/services/s3_test.go
@@ -102,7 +102,7 @@ func TestUploadToStorage(t *testing.T) {
 			mockS3.On("PutObject", mock.AnythingOfType("*s3.PutObjectInput")).Return(&s3.PutObjectOutput{}, tt.mockError)
 
 			file := bytes.NewReader([]byte(tt.fileContent))
-			url, err := UploadToStorage(file, tt.originalFilename, tt.contentType, testConfig)
+			url, err := UploadToS3Storage(file, tt.originalFilename, tt.contentType, testConfig)
 
 			if tt.mockError != nil {
 				assert.Error(t, err)

--- a/services/save_local.go
+++ b/services/save_local.go
@@ -1,0 +1,76 @@
+package services
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"git.difuse.io/Difuse/kalmia/config"
+	"github.com/gabriel-vasile/mimetype"
+)
+
+// Struct for saving assets
+type UploadedFileData struct {
+	OriginalName  string
+	DocId         string
+	MimeType      *mimetype.MIME
+	PageId        string
+	VersionId     string
+	VersionNumber string
+}
+
+// Saves to local disk in it's corresponding file with it's saved route
+// TODO: Make this operation "atomic"
+func SaveToLocal(fileBytes []byte, fileData *UploadedFileData) (string, error) {
+
+	assetPath := path.Join(config.ParsedConfig.DataPath, "rspress_data")
+	assetPath = path.Join(assetPath, "doc_"+fileData.DocId, "assets")
+
+	err := os.MkdirAll(assetPath, 0755)
+	if err != nil {
+		fmt.Printf("Error creating asset directory at path %s\n", assetPath)
+		return "", err
+	}
+
+	newFileName := path.Join(assetPath, generateFileName(fileData))
+
+	newFile, err := os.Create(newFileName)
+
+	if err != nil {
+		fmt.Printf("Error creating a new file %s\n", newFileName)
+		return "", err
+	}
+
+	defer newFile.Close()
+
+	bytesWritten, err := newFile.Write(fileBytes)
+
+	if err != nil {
+		fmt.Println("Error writing to the file", newFileName)
+	}
+	fmt.Println("Bytes written: ", bytesWritten)
+
+	// generate a file to be matched
+	return generateFileURL(fileData), nil
+}
+
+func generateFileName(fileData *UploadedFileData) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%s.%s",
+		fileData.OriginalName,
+		fileData.DocId,
+		fileData.PageId,
+		fileData.VersionId,
+		fileData.VersionNumber,
+		fileData.MimeType.Extension())
+}
+
+func generateFileURL(fileData *UploadedFileData) string {
+	return fmt.Sprintf(
+		"/kal-api/file/get?name=%s&type=%s&id=%s&pageId=%s&versionId=%s&version=%s",
+		generateFileName(fileData),
+		fileData.MimeType.String(),
+		fileData.DocId,
+		fileData.PageId,
+		fileData.VersionId,
+		fileData.VersionNumber)
+}

--- a/web/src/components/EditPage/EditPage.tsx
+++ b/web/src/components/EditPage/EditPage.tsx
@@ -113,13 +113,13 @@ const EditorWrapper: React.FC<EditorWrapperProps> = React.memo(
                 insertAlert(editor),
                 insertCode(editor),
               ],
-              query
+              query,
             )
           }
         />
       </BlockNoteView>
     );
-  }
+  },
 );
 
 EditorWrapper.displayName = "EditorWrapper";
@@ -206,11 +206,10 @@ export default function EditPage() {
         return {};
       }
     },
-    [t]
+    [t],
   );
 
   useEffect(() => {
-
     const fetchData = async () => {
       const result = await getPage(Number(pageId));
 
@@ -235,7 +234,7 @@ export default function EditPage() {
   }, [pageId, navigate, editor, t, parsedContent]);
 
   useEffect(() => {
-    if (editor && editorContent.length > 0) {  
+    if (editor && editorContent.length > 0) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       //@ts-ignore
       editor.replaceBlocks(editor.document, editorContent);
@@ -282,7 +281,7 @@ export default function EditPage() {
         navigate(`/dashboard/documentation?id=${docId}`);
       } else {
         navigate(
-          `/dashboard/documentation/page-group?id=${docId}&pageGroupId=${pageGroupId}&versionId=${versionID}&version=${version}`
+          `/dashboard/documentation/page-group?id=${docId}&pageGroupId=${pageGroupId}&versionId=${versionID}&version=${version}`,
         );
       }
     }
@@ -381,7 +380,7 @@ export default function EditPage() {
   };
 
   const handleImportFile = async (
-    e: ChangeEvent<HTMLInputElement>
+    e: ChangeEvent<HTMLInputElement>,
   ): Promise<void> => {
     const files = e.target.files;
 


### PR DESCRIPTION
- Added the ability to upload files, images, videos and audios on local disk
- It can be configured in `config.json`, by setting the value to `"assetStorage"` to `"local"`. It will use AWS S3 if set other wise and the credentials for AWS should be configured as usual.
- Default `"assetStorage"` is set to be `local` in `config.example.json` 
- By default the Max size of file is set to `10` MB but it can be changed in `config.json` by modifying `"maxFileSize"` value
- The config change is backwards compatible so it should not break any existing documents

Demo:

https://github.com/user-attachments/assets/630659c9-9b7c-476f-978b-720d90244b5b


