### PR TITLE
Local metadata upload

### DIFF
--- a/embedded/embedded.go
+++ b/embedded/embedded.go
@@ -36,7 +36,6 @@ func CopyEmbeddedFile(path string, to string) error {
 	}
 
 	embeddedHash, err := utils.FileHash(bytes.NewReader(content))
-
 	if err != nil {
 		return err
 	}

--- a/handlers/docs.go
+++ b/handlers/docs.go
@@ -62,28 +62,29 @@ func CreateDocumentation(service *services.ServiceRegistry, w http.ResponseWrite
 	}
 
 	type Request struct {
-		Name               string `json:"name" validate:"required"`
-		Description        string `json:"description" validate:"required"`
-		Version            string `json:"version" validate:"required"`
-		URL                string `json:"url" validate:"required"`
-		OrganizationName   string `json:"organizationName" validate:"required"`
-		LanderDetails      string `json:"landerDetails"`
-		ProjectName        string `json:"projectName" validate:"required"`
-		BaseURL            string `json:"baseURL" validate:"required"`
-		Favicon            string `json:"favicon"`
-		MetaImage          string `json:"metaImage"`
-		NavImage           string `json:"navImage"`
-		NavImageDark       string `json:"navImageDark"`
-		CustomCSS          string `json:"customCSS" validate:"required"`
-		FooterLabelLinks   string `json:"footerLabelLinks"`
-		MoreLabelLinks     string `json:"moreLabelLinks"`
-		CopyrightText      string `json:"copyrightText" validate:"required"`
-		RequireAuth        bool   `json:"requireAuth"`
-		GitRepo            string `json:"gitRepo"`
-		GitBranch          string `json:"gitBranch"`
-		GitUser            string `json:"gitUser"`
-		GitPassword        string `json:"gitPassword"`
-		GitEmail           string `json:"gitEmail"`
+		Name             string `json:"name" validate:"required"`
+		Description      string `json:"description" validate:"required"`
+		Version          string `json:"version" validate:"required"`
+		URL              string `json:"url" validate:"required"`
+		OrganizationName string `json:"organizationName" validate:"required"`
+		LanderDetails    string `json:"landerDetails"`
+		ProjectName      string `json:"projectName" validate:"required"`
+		BaseURL          string `json:"baseURL" validate:"required"`
+		Favicon          string `json:"favicon"`
+		MetaImage        string `json:"metaImage"`
+		NavImage         string `json:"navImage"`
+		NavImageDark     string `json:"navImageDark"`
+		CustomCSS        string `json:"customCSS" validate:"required"`
+		FooterLabelLinks string `json:"footerLabelLinks"`
+		MoreLabelLinks   string `json:"moreLabelLinks"`
+		CopyrightText    string `json:"copyrightText" validate:"required"`
+		RequireAuth      bool   `json:"requireAuth"`
+		GitRepo          string `json:"gitRepo"`
+		GitBranch        string `json:"gitBranch"`
+		GitUser          string `json:"gitUser"`
+		GitPassword      string `json:"gitPassword"`
+		GitEmail         string `json:"gitEmail"`
+
 		BucketFavicon      string `json:"bucketFavicon"`
 		BucketMetaImage    string `json:"bucketMetaImage"`
 		BucketNavImage     string `json:"bucketNavImage"`
@@ -163,6 +164,11 @@ func EditDocumentation(services *services.ServiceRegistry, w http.ResponseWriter
 		GitEmail         string `json:"gitEmail"`
 		GitUser          string `json:"gitUser"`
 		GitPassword      string `json:"gitPassword"`
+
+		BucketFavicon      string `json:"bucketFavicon"`
+		BucketMetaImage    string `json:"bucketMetaImage"`
+		BucketNavImage     string `json:"bucketNavImage"`
+		BucketNavImageDark string `json:"bucketNavImageDark"`
 	}
 
 	req, err := ValidateRequest[Request](w, r)
@@ -182,10 +188,37 @@ func EditDocumentation(services *services.ServiceRegistry, w http.ResponseWriter
 		return
 	}
 
-	err = services.DocService.EditDocumentation(user, req.ID, req.Name, req.Description, req.Version, req.Favicon, req.MetaImage,
-		req.NavImage, req.NavImageDark, req.CustomCSS, req.FooterLabelLinks, req.MoreLabelLinks, req.CopyrightText,
-		req.URL, req.OrganizationName, req.ProjectName, req.BaseURL, req.LanderDetails, req.RequireAuth, req.GitRepo,
-		req.GitBranch, req.GitUser, req.GitPassword, req.GitEmail)
+	err = services.DocService.EditDocumentation(user,
+		req.ID,
+		req.Name,
+		req.Description,
+		req.Version,
+		req.Favicon,
+		req.MetaImage,
+		req.NavImage,
+		req.NavImageDark,
+		req.CustomCSS,
+		req.FooterLabelLinks,
+		req.MoreLabelLinks,
+		req.CopyrightText,
+		req.URL,
+		req.OrganizationName,
+		req.ProjectName,
+		req.BaseURL,
+		req.LanderDetails,
+		req.RequireAuth,
+		req.GitRepo,
+		req.GitBranch,
+		req.GitUser,
+		req.GitPassword,
+		req.GitEmail,
+		map[string]string{
+			"favicon":      req.BucketFavicon,
+			"metaImage":    req.BucketMetaImage,
+			"navImage":     req.BucketNavImage,
+			"navImageDark": req.BucketNavImageDark,
+		},
+	)
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return

--- a/handlers/docs.go
+++ b/handlers/docs.go
@@ -15,7 +15,6 @@ import (
 
 func GetDocumentations(service *services.DocService, w http.ResponseWriter, r *http.Request) {
 	docs, err := service.GetDocumentations()
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{
 			"status":  "error",
@@ -33,13 +32,11 @@ func GetDocumentation(service *services.DocService, w http.ResponseWriter, r *ht
 	}
 
 	req, err := ValidateRequest[Request](w, r)
-
 	if err != nil {
 		return
 	}
 
 	doc, err := service.GetDocumentation(req.ID)
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{
 			"status":  "error",
@@ -51,48 +48,49 @@ func GetDocumentation(service *services.DocService, w http.ResponseWriter, r *ht
 	SendJSONResponse(http.StatusOK, w, doc)
 }
 
-func CreateDocumentation(services *services.ServiceRegistry, w http.ResponseWriter, r *http.Request) {
+func CreateDocumentation(service *services.ServiceRegistry, w http.ResponseWriter, r *http.Request) {
 	token, err := GetTokenFromHeader(r)
-
 	if err != nil {
 		SendJSONResponse(http.StatusUnauthorized, w, map[string]string{"status": "error", "message": "invalid_token"})
 		return
 	}
 
-	user, err := services.AuthService.GetUserFromToken(token)
-
+	user, err := service.AuthService.GetUserFromToken(token)
 	if err != nil {
 		SendJSONResponse(http.StatusUnauthorized, w, map[string]string{"status": "error", "message": "invalid_token"})
 		return
 	}
 
 	type Request struct {
-		Name             string `json:"name" validate:"required"`
-		Description      string `json:"description" validate:"required"`
-		Version          string `json:"version" validate:"required"`
-		URL              string `json:"url" validate:"required"`
-		OrganizationName string `json:"organizationName" validate:"required"`
-		LanderDetails    string `json:"landerDetails"`
-		ProjectName      string `json:"projectName" validate:"required"`
-		BaseURL          string `json:"baseURL" validate:"required"`
-		Favicon          string `json:"favicon"`
-		MetaImage        string `json:"metaImage"`
-		NavImage         string `json:"navImage"`
-		NavImageDark     string `json:"navImageDark"`
-		CustomCSS        string `json:"customCSS" validate:"required"`
-		FooterLabelLinks string `json:"footerLabelLinks"`
-		MoreLabelLinks   string `json:"moreLabelLinks"`
-		CopyrightText    string `json:"copyrightText" validate:"required"`
-		RequireAuth      bool   `json:"requireAuth"`
-		GitRepo          string `json:"gitRepo"`
-		GitBranch        string `json:"gitBranch"`
-		GitUser          string `json:"gitUser"`
-		GitPassword      string `json:"gitPassword"`
-		GitEmail         string `json:"gitEmail"`
+		Name               string `json:"name" validate:"required"`
+		Description        string `json:"description" validate:"required"`
+		Version            string `json:"version" validate:"required"`
+		URL                string `json:"url" validate:"required"`
+		OrganizationName   string `json:"organizationName" validate:"required"`
+		LanderDetails      string `json:"landerDetails"`
+		ProjectName        string `json:"projectName" validate:"required"`
+		BaseURL            string `json:"baseURL" validate:"required"`
+		Favicon            string `json:"favicon"`
+		MetaImage          string `json:"metaImage"`
+		NavImage           string `json:"navImage"`
+		NavImageDark       string `json:"navImageDark"`
+		CustomCSS          string `json:"customCSS" validate:"required"`
+		FooterLabelLinks   string `json:"footerLabelLinks"`
+		MoreLabelLinks     string `json:"moreLabelLinks"`
+		CopyrightText      string `json:"copyrightText" validate:"required"`
+		RequireAuth        bool   `json:"requireAuth"`
+		GitRepo            string `json:"gitRepo"`
+		GitBranch          string `json:"gitBranch"`
+		GitUser            string `json:"gitUser"`
+		GitPassword        string `json:"gitPassword"`
+		GitEmail           string `json:"gitEmail"`
+		BucketFavicon      string `json:"bucketFavicon"`
+		BucketMetaImage    string `json:"bucketMetaImage"`
+		BucketNavImage     string `json:"bucketNavImage"`
+		BucketNavImageDark string `json:"bucketNavImageDark"`
 	}
 
 	req, err := ValidateRequest[Request](w, r)
-
 	if err != nil {
 		return
 	}
@@ -126,8 +124,12 @@ func CreateDocumentation(services *services.ServiceRegistry, w http.ResponseWrit
 		GitEmail:         req.GitEmail,
 	}
 
-	err = services.DocService.CreateDocumentation(documentation, user)
-
+	err = service.DocService.CreateDocumentation(documentation, user, map[string]string{
+		"favicon":      req.BucketFavicon,
+		"metaImage":    req.BucketMetaImage,
+		"navImage":     req.BucketNavImage,
+		"navImageDark": req.BucketNavImageDark,
+	})
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return
@@ -164,7 +166,6 @@ func EditDocumentation(services *services.ServiceRegistry, w http.ResponseWriter
 	}
 
 	req, err := ValidateRequest[Request](w, r)
-
 	if err != nil {
 		return
 	}
@@ -185,7 +186,6 @@ func EditDocumentation(services *services.ServiceRegistry, w http.ResponseWriter
 		req.NavImage, req.NavImageDark, req.CustomCSS, req.FooterLabelLinks, req.MoreLabelLinks, req.CopyrightText,
 		req.URL, req.OrganizationName, req.ProjectName, req.BaseURL, req.LanderDetails, req.RequireAuth, req.GitRepo,
 		req.GitBranch, req.GitUser, req.GitPassword, req.GitEmail)
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return
@@ -200,13 +200,11 @@ func DeleteDocumentation(service *services.DocService, w http.ResponseWriter, r 
 	}
 
 	req, err := ValidateRequest[Request](w, r)
-
 	if err != nil {
 		return
 	}
 
 	err = service.DeleteDocumentation(req.ID)
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return
@@ -222,13 +220,11 @@ func CreateDocumentationVersion(service *services.DocService, w http.ResponseWri
 	}
 
 	req, err := ValidateRequest[Request](w, r)
-
 	if err != nil {
 		return
 	}
 
 	err = service.CreateDocumentationVersion(req.OriginalDocID, req.NewVersion)
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return
@@ -239,7 +235,6 @@ func CreateDocumentationVersion(service *services.DocService, w http.ResponseWri
 
 func GetPages(service *services.DocService, w http.ResponseWriter, r *http.Request) {
 	pages, err := service.GetPages()
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return
@@ -254,13 +249,11 @@ func GetPage(service *services.DocService, w http.ResponseWriter, r *http.Reques
 	}
 
 	req, err := ValidateRequest[Request](w, r)
-
 	if err != nil {
 		return
 	}
 
 	page, err := service.GetPage(req.ID)
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return
@@ -280,20 +273,17 @@ func CreatePage(services *services.ServiceRegistry, w http.ResponseWriter, r *ht
 	}
 
 	req, err := ValidateRequest[Request](w, r)
-
 	if err != nil {
 		return
 	}
 
 	token, err := GetTokenFromHeader(r)
-
 	if err != nil {
 		SendJSONResponse(http.StatusUnauthorized, w, map[string]string{"status": "error", "message": "invalid_request"})
 		return
 	}
 
 	user, err := services.AuthService.GetUserFromToken(token)
-
 	if err != nil {
 		SendJSONResponse(http.StatusUnauthorized, w, map[string]string{"status": "error", "message": "invalid_request"})
 		return
@@ -319,7 +309,6 @@ func CreatePage(services *services.ServiceRegistry, w http.ResponseWriter, r *ht
 	}
 
 	err = services.DocService.CreatePage(&page)
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return
@@ -434,20 +423,17 @@ func CreatePageGroup(services *services.ServiceRegistry, w http.ResponseWriter, 
 	}
 
 	req, err := ValidateRequest[Request](w, r)
-
 	if err != nil {
 		return
 	}
 
 	token, err := GetTokenFromHeader(r)
-
 	if err != nil {
 		SendJSONResponse(http.StatusUnauthorized, w, map[string]string{"status": "error", "message": "invalid_request"})
 		return
 	}
 
 	user, err := services.AuthService.GetUserFromToken(token)
-
 	if err != nil {
 		SendJSONResponse(http.StatusUnauthorized, w, map[string]string{"status": "error", "message": "invalid_request"})
 		return
@@ -471,7 +457,6 @@ func CreatePageGroup(services *services.ServiceRegistry, w http.ResponseWriter, 
 	}
 
 	_, err = services.DocService.CreatePageGroup(&pageGroup)
-
 	if err != nil {
 		SendJSONResponse(http.StatusInternalServerError, w, map[string]string{"status": "error", "message": err.Error()})
 		return

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func main() {
 	authRouter.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) { handlers.GetUsers(aS, w, r) }).Methods("GET")
 	authRouter.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) { handlers.GetUser(aS, w, r) }).Methods("POST")
 	authRouter.HandleFunc("/user/upload-file", func(w http.ResponseWriter, r *http.Request) { handlers.UploadFile(d, w, r, config.ParsedConfig) }).Methods("POST")
+	authRouter.HandleFunc("/user/assets/upload-file", func(w http.ResponseWriter, r *http.Request) { handlers.UploadAssetsFile(d, w, r, config.ParsedConfig) }).Methods("POST")
 
 	authRouter.HandleFunc("/jwt/create", func(w http.ResponseWriter, r *http.Request) { handlers.CreateJWT(aS, w, r) }).Methods("POST")
 	authRouter.HandleFunc("/jwt/refresh", func(w http.ResponseWriter, r *http.Request) { handlers.RefreshJWT(aS, w, r) }).Methods("POST")

--- a/services/docs_rspress.go
+++ b/services/docs_rspress.go
@@ -1128,7 +1128,7 @@ func (service *DocService) RsPressBuild(docId uint, rebuild bool) error {
 			return err
 		}
 
-		err = utils.CopyPublicAssetsToDocs(docPath)
+		err = utils.CopyPublicAssetsToDocsIfEmpty(docPath)
 		if err != nil {
 			return err
 		}
@@ -1364,6 +1364,18 @@ func (service *DocService) BuildJob() {
 				logger.Error("Failed to deploy to git", zap.Error(err))
 			} else {
 				logger.Info("Git Deploy completed", zap.Uint("doc_id", docID), zap.Duration("elapsed", gitElapsed), zap.Int("trigger_count", len(groupTriggers)))
+			}
+			logger.Info(fmt.Sprintf("moving static assets to docs in doc_%d", docID))
+
+			docPath := utils.GetDocPathByID(docID, config.ParsedConfig)
+			docPublicAssetPath := filepath.Join(docPath, "public")
+			docsInternalPublicAssetPath := filepath.Join(docPath, "docs", "public")
+			err = utils.CopyOrOveriteDir(docPublicAssetPath, docsInternalPublicAssetPath)
+
+			if err != nil {
+				logger.Error(fmt.Sprintf("error copying files from %s to %s", docPublicAssetPath, docsInternalPublicAssetPath), zap.Error(err))
+			} else {
+				logger.Info("successfully copied files to target", zap.Uint("doc_id", docID))
 			}
 		}
 

--- a/services/docs_rspress.go
+++ b/services/docs_rspress.go
@@ -73,13 +73,11 @@ type MetaData struct {
 func (service *DocService) GenerateHead(docID uint, pageId uint, pageType string) (string, error) {
 	var buffer bytes.Buffer
 	doc, err := service.GetDocumentation(docID)
-
 	if err != nil {
 		return "", err
 	}
 
 	latest, _, err := service.GetAllVersions(docID)
-
 	if err != nil {
 		return "", err
 	}
@@ -115,7 +113,6 @@ func (service *DocService) GenerateHead(docID uint, pageId uint, pageType string
 		}
 
 		metaJSON, err := json.Marshal(meta)
-
 		if err != nil {
 			return "", err
 		}
@@ -190,7 +187,6 @@ func (service *DocService) GenerateHead(docID uint, pageId uint, pageType string
 		}
 
 		metaJSON, err := json.Marshal(meta)
-
 		if err != nil {
 			return "", err
 		}
@@ -254,7 +250,6 @@ func (service *DocService) UpdateWriteBuild(docId uint) error {
 	}
 
 	configHash, err := service.StartUpdate(docId, rootParentId)
-
 	if err != nil {
 		return err
 	}
@@ -308,7 +303,6 @@ func (service *DocService) StartupCheck() error {
 	}
 
 	err = service.InitRsPressPackageCache()
-
 	if err != nil {
 		logger.Fatal("Initializing Package Cache Failed...", zap.Error(err))
 	}
@@ -329,7 +323,6 @@ func (service *DocService) StartupCheck() error {
 		}
 
 		err = service.AddBuildTrigger(doc.ID, false)
-
 		if err != nil {
 			logger.Error("Failed to add build trigger", zap.Uint("doc_id", doc.ID), zap.Error(err))
 		}
@@ -358,7 +351,6 @@ func (service *DocService) InitRsPressPackageCache() error {
 	installStart := time.Now()
 
 	err = utils.RunNpmCommand(packageCachePath, "install")
-
 	if err != nil {
 		return err
 	}
@@ -382,7 +374,6 @@ func (service *DocService) InitRsPress(docId uint) error {
 	}
 
 	err := embedded.CopyInitFiles(docPath)
-
 	if err != nil {
 		return err
 	}
@@ -394,7 +385,6 @@ func (service *DocService) InitRsPress(docId uint) error {
 	}
 
 	err = utils.RunNpmCommand(docPath, "install")
-
 	if err != nil {
 		return err
 	}
@@ -409,7 +399,6 @@ func (service *DocService) StartUpdate(docId uint, rootParentId uint) (string, e
 	}
 
 	docConfigTemplate, err := embedded.ReadEmbeddedFile("rspress.config.ts")
-
 	if err != nil {
 		return "", err
 	}
@@ -471,7 +460,6 @@ func (service *DocService) StartUpdate(docId uint, rootParentId uint) (string, e
 		var socialLinksRsPress []SocialLinkRsPress
 
 		err := json.Unmarshal([]byte(doc.FooterLabelLinks), &socialLinks)
-
 		if err != nil {
 			replacements["__SOCIAL_LINKS__"] = "[]"
 		}
@@ -481,7 +469,6 @@ func (service *DocService) StartUpdate(docId uint, rootParentId uint) (string, e
 		}
 
 		socialLinksJSON, err := json.Marshal(socialLinksRsPress)
-
 		if err != nil {
 			replacements["__SOCIAL_LINKS__"] = "[]"
 		}
@@ -522,14 +509,12 @@ func (service *DocService) StartUpdate(docId uint, rootParentId uint) (string, e
 	}
 
 	latest, versions, err := service.GetAllVersions(docId)
-
 	if err != nil {
 		return "", err
 	}
 
 	multiVersions := Versions{Default: latest, Versions: versions}
 	multiVersionsJSON, err := json.Marshal(multiVersions)
-
 	if err != nil {
 		return "", err
 	}
@@ -537,7 +522,6 @@ func (service *DocService) StartUpdate(docId uint, rootParentId uint) (string, e
 	replacements["__MULTI_VERSIONS__"] = "multiVersion: " + string(multiVersionsJSON)
 
 	err = utils.WriteToFile(docConfig, utils.ReplaceMany(string(docConfigTemplate), replacements))
-
 	if err != nil {
 		return "", err
 	}
@@ -546,13 +530,11 @@ func (service *DocService) StartUpdate(docId uint, rootParentId uint) (string, e
 	replacements["__OUT_DIR__"] = "gitbuild"
 
 	err = utils.WriteToFile(gitDocConfig, utils.ReplaceMany(string(docConfigTemplate), replacements))
-
 	if err != nil {
 		return "", err
 	}
 
 	configHash, err := utils.FileHash(docConfig)
-
 	if err != nil {
 		return "", err
 	}
@@ -807,7 +789,6 @@ func (service *DocService) buildVersionTree(docId uint) ([]VersionInfo, error) {
 func (service *DocService) WriteContents(docId uint, rootParentId uint, preHash string) error {
 	docIdPath := filepath.Join(config.ParsedConfig.DataPath, "rspress_data", "doc_"+strconv.Itoa(int(rootParentId)))
 	_, err := service.GetDocumentation(docId)
-
 	if err != nil {
 		if err.Error() == "documentation_not_found" {
 			if err := utils.RemovePath(docIdPath); err != nil {
@@ -826,14 +807,12 @@ func (service *DocService) WriteContents(docId uint, rootParentId uint, preHash 
 	}
 
 	versionInfos, err := service.buildVersionTree(rootParentId)
-
 	if err != nil {
 		return err
 	}
 
 	for _, versionInfo := range versionInfos {
 		versionDoc, err := service.GetDocumentation(versionInfo.DocId)
-
 		if err != nil {
 			return err
 		}
@@ -954,20 +933,17 @@ func (service *DocService) WriteContents(docId uint, rootParentId uint, preHash 
 	}
 
 	newDocsHash, err := utils.DirHash(docsPath)
-
 	if err != nil {
 		return err
 	}
 
 	newConfigHash, err := utils.FileHash(filepath.Join(docIdPath, "rspress.config.ts"))
-
 	if err != nil {
 		return err
 	}
 
 	newHash := utils.HashStrings([]string{newDocsHash, newConfigHash})
 	deletionsOccurred, err := service.PreBuildCleanup(rootParentId)
-
 	if err != nil {
 		return err
 	}
@@ -1003,7 +979,6 @@ func (service *DocService) WriteHomePage(documentation models.Documentation, con
 		}
 
 		err := json.Unmarshal([]byte(documentation.LanderDetails), &landerDetails)
-
 		if err != nil {
 			return fmt.Errorf("error unmarshaling LanderDetails: %w", err)
 		}
@@ -1058,7 +1033,6 @@ func (service *DocService) WriteHomePage(documentation models.Documentation, con
 		}
 
 		metaJSON, err := json.Marshal(meta)
-
 		if err != nil {
 			return err
 		}
@@ -1069,7 +1043,6 @@ func (service *DocService) WriteHomePage(documentation models.Documentation, con
 		homePagePath = filepath.Join(contentPath, "../", "index.mdx")
 	} else {
 		head, err := service.GenerateHead(documentation.ID, math.MaxUint32, "doc")
-
 		if err != nil {
 			logger.Error("Failed to generate head for home page", zap.Error(err))
 		}
@@ -1155,6 +1128,11 @@ func (service *DocService) RsPressBuild(docId uint, rebuild bool) error {
 			return err
 		}
 
+		err = utils.CopyPublicAssetsToDocs(docPath)
+		if err != nil {
+			return err
+		}
+
 		err = utils.RunNpmCommand(docPath, "run", "build")
 		if err != nil {
 			return err
@@ -1212,13 +1190,11 @@ func (service *DocService) GetRsPress(urlPath string) (uint, string, string, boo
 				split := strings.Split(cacheKey, "|")
 				docID := strings.TrimPrefix("doc_", split[1])
 				reqAuth, err := strconv.ParseBool(split[2])
-
 				if err != nil {
 					continue
 				}
 
 				id, err := strconv.Atoi(docID)
-
 				if err != nil {
 					continue
 				}
@@ -1266,7 +1242,6 @@ func (service *DocService) GetRsPress(urlPath string) (uint, string, string, boo
 	}
 
 	files, err := os.ReadDir(docPath)
-
 	if err != nil {
 		return 0, "", "", false, fmt.Errorf("error_reading_rspress_directory")
 	}
@@ -1315,7 +1290,6 @@ func (service *DocService) DeleteJob() {
 		if utils.PathExists(docPath) {
 			logger.Info("Deleting doc folder", zap.Uint("doc_id", trigger.DocumentationID))
 			err := service.RemoveDocFolder(trigger.DocumentationID)
-
 			if err != nil {
 				logger.Error("(DeleteJob) Failed to remove doc folder", zap.Error(err))
 				skipSave = true

--- a/utils/docs.go
+++ b/utils/docs.go
@@ -7,7 +7,7 @@ import (
 	"git.difuse.io/Difuse/kalmia/logger"
 )
 
-func CopyPublicAssetsToDocs(docPath string) error {
+func CopyPublicAssetsToDocsIfEmpty(docPath string) error {
 	publicAssetsDirPath := filepath.Join(docPath, "public")
 	innerDocPath := filepath.Join(docPath, "docs")
 
@@ -32,4 +32,38 @@ func CopyPublicAssetsToDocs(docPath string) error {
 		}
 	}
 	return nil
+}
+
+func CopyOrOveriteDir(sourceDir, destDir string) error {
+	sourceDirEntry, err := os.ReadDir(sourceDir)
+	if err != nil {
+		return err
+	}
+	for _, file := range sourceDirEntry {
+		exists, err := IsFileExistsInDir(file.Name(), destDir)
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			err = os.RemoveAll(filepath.Join(destDir, file.Name()))
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return os.CopyFS(destDir, os.DirFS(sourceDir))
+}
+
+func IsFileExistsInDir(filename string, dirname string) (bool, error) {
+	_, err := os.Stat(filepath.Join(dirname, filename))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
 }

--- a/utils/docs.go
+++ b/utils/docs.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+
+	"git.difuse.io/Difuse/kalmia/logger"
+)
+
+func CopyPublicAssetsToDocs(docPath string) error {
+	publicAssetsDirPath := filepath.Join(docPath, "public")
+	innerDocPath := filepath.Join(docPath, "docs")
+
+	innerDocPublicPath := filepath.Join(innerDocPath, "public")
+	if !PathExists(innerDocPublicPath) {
+		if err := MakeDir(innerDocPublicPath); err != nil {
+			logger.Error("error creating public folder in: " + innerDocPublicPath)
+			logger.Error(err.Error())
+			return err
+		}
+	}
+
+	isEmptyDir, err := IsEmptyDir(innerDocPublicPath)
+	if err != nil {
+		return err
+	}
+
+	if isEmptyDir {
+		err = os.CopyFS(innerDocPublicPath, os.DirFS(publicAssetsDirPath))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/utils/fs.go
+++ b/utils/fs.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"git.difuse.io/Difuse/kalmia/config"
 	"golang.org/x/mod/sumdb/dirhash"
 )
 
@@ -19,7 +20,6 @@ func PathExists(path string) bool {
 
 func CopyFile(src, dst string) error {
 	sourceFile, err := os.Open(src)
-
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,6 @@ func TouchFile(path string) error {
 	}
 
 	_, err = file.WriteString("1")
-
 	if err != nil {
 		return err
 	}
@@ -171,4 +170,33 @@ func DirHash(dir string) (string, error) {
 		return "", err
 	}
 	return hash, nil
+}
+
+func GetFileExtension(filename string) string {
+	tmpStringSlice := strings.Split(filename, ".")
+
+	extension := tmpStringSlice[len(tmpStringSlice)-1]
+
+	return extension
+}
+
+func GetDocPathByID(docID uint, cfg *config.Config) string {
+	return filepath.Join(cfg.DataPath, "rspress_data", fmt.Sprintf("doc_%d", docID))
+}
+
+func IsEmptyDir(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+
+	if err == io.EOF {
+		return true, nil
+	}
+
+	return false, err
 }

--- a/web/src/api/Requests.ts
+++ b/web/src/api/Requests.ts
@@ -45,6 +45,12 @@ export interface DocumentationPayload {
   gitEmail?: string;
   gitPassword?: string;
   gitBranch?: string;
+
+  // stored in bucket named
+  bucketFavicon: string;
+  bucketMetaImage: string;
+  bucketNavImage: string;
+  bucketNavImageDark: string;
 }
 
 interface CreateVersionPayload {
@@ -272,6 +278,9 @@ export const updateUser = (data: UpdateUserPayload) =>
 
 export const uploadFile = (data: FormData) =>
   makeRequest("/kal-api/auth/user/upload-file", "post", data);
+
+export const uploadAssetsFile = (data: FormData) =>
+  makeRequest("/kal-api/auth/user/assets/upload-file", "post", data);
 
 export const deleteUser = (username: string) =>
   makeRequest("/kal-api/auth/user/delete", "post", { username });

--- a/web/src/components/CreateDocumentModal/CreateDocModal.tsx
+++ b/web/src/components/CreateDocumentModal/CreateDocModal.tsx
@@ -37,7 +37,6 @@ import {
   MoreLabelLinks,
 } from "../../types/doc";
 import {
-  capitalizeFirstLetter,
   convertToEmoji,
   handleError,
   landingPageValidate,
@@ -379,7 +378,6 @@ export default function CreateDocModal() {
 
     const file = files[0]
 
-
     const formData = new globalThis.FormData()
 
     formData.append("upload_tag_name", name)
@@ -404,6 +402,7 @@ export default function CreateDocModal() {
       ...prevData,
       [name]: { name: res.data?.file, uploaded: true }
     }))
+
     toastMessage("updated_file", "success")
     // DEBUG: remove after debug session
     console.log("Uploaded files: ", uploadedFiles)
@@ -748,13 +747,13 @@ export default function CreateDocModal() {
                     name="copyrightText"
                     required={true}
                   />
-                  <FormField
+
+                  <UploadFormField
                     label={t("social_card_image")}
                     placeholder={t("social_card_image_palceholder")}
-                    value={formData?.metaImage}
-                    onChange={handleChange}
+                    onChange={handleUploadAssetFile}
                     name="metaImage"
-                    type="url"
+                    uploaded={uploadedFiles.metaImage.uploaded}
                   />
                 </div>
 

--- a/web/src/components/CreateDocumentModal/CreateDocModal.tsx
+++ b/web/src/components/CreateDocumentModal/CreateDocModal.tsx
@@ -15,10 +15,12 @@ import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import {
+  ApiResponse,
   createDocumentation,
   DocumentationPayload,
   getDocumentation,
   updateDocumentation,
+  uploadAssetsFile,
 } from "../../api/Requests";
 import { ModalContext } from "../../context/ModalContext";
 import { ThemeContext, ThemeContextType } from "../../context/ThemeContext";
@@ -35,6 +37,7 @@ import {
   MoreLabelLinks,
 } from "../../types/doc";
 import {
+  capitalizeFirstLetter,
   convertToEmoji,
   handleError,
   landingPageValidate,
@@ -45,6 +48,8 @@ import {
 import { toastMessage } from "../../utils/Toast";
 import { customCSSInitial, SocialLinkIcon } from "../../utils/Utils";
 import Breadcrumb from "../Breadcrumb/Breadcrumb";
+import { UploadFormField } from "./UploadFormField";
+import { AxiosError } from "axios";
 
 const FormField: React.FC<FormFieldData> = ({
   label,
@@ -339,6 +344,71 @@ export default function CreateDocModal() {
     }
   }, []);
 
+  const [uploadedFiles, setUploadedFiles] = useState<{ [name: string]: { name?: string, uploaded: boolean } }>({
+    favicon: {
+      name: "",
+      uploaded: false
+    },
+    navImageDark: {
+      name: "",
+      uploaded: false
+    },
+    navImage: {
+      name: "",
+      uploaded: false
+    },
+    metaImage: {
+      name: "",
+      uploaded: false
+    }
+  })
+
+  const handleUploadAssetFile = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name } = e.target
+
+    // check for files
+
+    const { files } = e.target
+
+    if (!files) {
+      toastMessage("no_files_selected", "warning")
+      return
+    }
+
+    const file = files[0]
+
+
+    const formData = new globalThis.FormData()
+
+    formData.append("upload_tag_name", name)
+    formData.append(name, file)
+
+    let res: ApiResponse<{ status: "error" | "success", message: string, file: string }>
+
+    try {
+      res = await uploadAssetsFile(formData)
+    } catch (error) {
+
+      const err = error as AxiosError
+      toastMessage(err.message, "error")
+      return
+    }
+    if (!res.data) {
+      toastMessage("no_response_from_server", "error")
+      return
+    }
+
+    setUploadedFiles((prevData) => ({
+      ...prevData,
+      [name]: { name: res.data?.file, uploaded: true }
+    }))
+    toastMessage("updated_file", "success")
+    // DEBUG: remove after debug session
+    console.log("Uploaded files: ", uploadedFiles)
+  }
+
   const handleChange = (
     e:
       | React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -412,6 +482,10 @@ export default function CreateDocModal() {
       moreLabelLinks: moreField
         ? JSON.stringify(moreField)
         : [{ label: "", link: "" }],
+      bucketFavicon: uploadedFiles.favicon.name || "",
+      bucketMetaImage: uploadedFiles.metaImage.name || "",
+      bucketNavImage: uploadedFiles.navImage.name || "",
+      bucketNavImageDark: uploadedFiles.navImageDark.name || ""
     };
     let result;
 
@@ -614,31 +688,55 @@ export default function CreateDocModal() {
                 </div>
 
                 <div className="grid gap-4 sm:grid-cols-3">
-                  <FormField
+                  {/* <FormField */}
+                  {/*   label={t("favicon")} */}
+                  {/*   placeholder={t("favicon_placeholder")} */}
+                  {/*   value={formData?.favicon} */}
+                  {/*   onChange={handleChange} */}
+                  {/*   name="favicon" */}
+                  {/*   type="url" */}
+                  {/* /> */}
+                  {/* <FormField */}
+                  {/*   label={t("navbar_icon_dark")} */}
+                  {/*   placeholder={t("navbar_icon_placeholder")} */}
+                  {/*   value={formData?.navImageDark} */}
+                  {/*   onChange={handleChange} */}
+                  {/*   name="navImageDark" */}
+                  {/*   type="url" */}
+                  {/* /> */}
+                  {/* <FormField */}
+                  {/*   label={t("navbar_icon")} */}
+                  {/*   placeholder={t("navbar_icon_placeholder")} */}
+                  {/*   value={formData?.navImage} */}
+                  {/*   onChange={handleChange} */}
+                  {/*   name="navImage" */}
+                  {/*   type="url" */}
+                  {/* /> */}
+
+                  <UploadFormField
                     label={t("favicon")}
                     placeholder={t("favicon_placeholder")}
-                    value={formData?.favicon}
-                    onChange={handleChange}
+                    onChange={handleUploadAssetFile}
                     name="favicon"
-                    type="url"
+                    uploaded={uploadedFiles.favicon.uploaded}
                   />
 
-                  <FormField
+                  <UploadFormField
                     label={t("navbar_icon_dark")}
                     placeholder={t("navbar_icon_placeholder")}
-                    value={formData?.navImageDark}
-                    onChange={handleChange}
+                    onChange={handleUploadAssetFile}
                     name="navImageDark"
-                    type="url"
+                    uploaded={uploadedFiles.navImageDark.uploaded}
                   />
-                  <FormField
+
+                  <UploadFormField
                     label={t("navbar_icon")}
                     placeholder={t("navbar_icon_placeholder")}
-                    value={formData?.navImage}
-                    onChange={handleChange}
+                    onChange={handleUploadAssetFile}
                     name="navImage"
-                    type="url"
+                    uploaded={uploadedFiles.navImage.uploaded}
                   />
+
                 </div>
 
                 <div className="grid gap-4 sm:grid-cols-2">

--- a/web/src/components/CreateDocumentModal/UploadFormField.tsx
+++ b/web/src/components/CreateDocumentModal/UploadFormField.tsx
@@ -1,0 +1,35 @@
+import { UploadFormFieldData } from "../../types/doc";
+import { Icon } from "@iconify/react"
+
+export const UploadFormField: React.FC<UploadFormFieldData> = ({
+  label,
+  placeholder,
+  onChange,
+  name,
+  required = false,
+  ref,
+  uploaded
+}) => {
+
+  return (
+    <div>
+      <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+        {label} {required && <span className="text-red-500 ml-1">*</span>}
+      </span>
+      <div className="relative  flex justify-center items-center">
+        <input
+          ref={ref}
+          onChange={onChange}
+          type={"file"}
+          name={name}
+          id={name}
+          className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg block w-full p-2.5 pr-10 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
+          placeholder={placeholder}
+          required={required}
+        />
+
+        {uploaded && <Icon icon="solar:check-circle-bold" className="w-6 h-6 text-green-400" />}
+      </div>
+    </div>
+  );
+};

--- a/web/src/components/GitBookModal/GitBookModal.tsx
+++ b/web/src/components/GitBookModal/GitBookModal.tsx
@@ -161,6 +161,11 @@ export default function GitBookModal() {
           "https://downloads-bucket.difuse.io/kalmia-sideways-white-final.png",
         customCSS: customCSSInitial(),
         copyrightText: "N/A",
+
+        bucketFavicon: "",
+        bucketMetaImage: "",
+        bucketNavImage: "",
+        bucketNavImageDark: ""
       };
 
       const createResponse = await createDocumentation(payload);

--- a/web/src/types/doc.ts
+++ b/web/src/types/doc.ts
@@ -132,6 +132,27 @@ export interface FormFieldData {
   ref?: React.Ref<HTMLInputElement>;
 }
 
+export interface UploadFormField {
+  label: string;
+  placeholder: string;
+  value: string;
+  onChange: () => Promise<void>;
+  name: string;
+  type: string;
+  required: boolean;
+  ref: React.RefObject<HTMLInputElement>;
+}
+export interface UploadFormFieldData {
+  label: string;
+  placeholder: string;
+  value?: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  name: string;
+  required?: boolean;
+  uploaded?: boolean;
+  ref?: React.Ref<HTMLInputElement>;
+}
+
 export interface FormData {
   name: string;
   description: string;

--- a/web/src/utils/Common.ts
+++ b/web/src/utils/Common.ts
@@ -337,18 +337,18 @@ export const validateFormData = (
     }
   }
 
-  const urlFields: (keyof CreateDocumentFormData)[] = [
-    "favicon",
-    "navImageDark",
-    "navImage",
-    "metaImage",
-  ];
-
-  for (const field of urlFields) {
-    if (formData[field] && !isValidURL(formData[field])) {
-      return { status: true, message: `valid_${field}_url_required` };
-    }
-  }
+  // const urlFields: (keyof CreateDocumentFormData)[] = [
+  //   "favicon",
+  //   "navImageDark",
+  //   "navImage",
+  //   "metaImage",
+  // ];
+  //
+  // for (const field of urlFields) {
+  //   if (formData[field] && !isValidURL(formData[field])) {
+  //     return { status: true, message: `valid_${field}_url_required` };
+  //   }
+  // }
 
   if (!isValidBaseURL(formData.baseURL)) {
     return { status: true, message: "valid_base_url_required" };

--- a/web/src/utils/Common.ts
+++ b/web/src/utils/Common.ts
@@ -601,3 +601,7 @@ export const setCookie = (name: string, value: string, days: number) => {
 export const b64ToString = (base64: string) => {
   return window.atob(base64);
 };
+
+export const capitalizeFirstLetter = (word: string) => {
+  return word.charAt(0).toUpperCase() + word.slice(1);
+}


### PR DESCRIPTION
Allows users to upload meta data assets(favicon, nav image, meta image) for their docs, locally from disk
It simply accepts the uploaded asset and places it in the docs uploaded folder which rspress builds and embeds into the docs.
Also works if user edits their existing docs to upload the data 