### PR TITLE
Ensure public assets directory exists and Fix routing for non ascii letter  

### DIFF
--- a/utils/docs.go
+++ b/utils/docs.go
@@ -26,6 +26,11 @@ func CopyPublicAssetsToDocsIfEmpty(docPath string) error {
 	}
 
 	if isEmptyDir {
+		// make sure destination exists
+		if err := MakeDir(publicAssetsDirPath); err != nil {
+			logger.Error("could not create dest dir: " + publicAssetsDirPath)
+			return err
+		}
 		err = os.CopyFS(innerDocPublicPath, os.DirFS(publicAssetsDirPath))
 		if err != nil {
 			return err

--- a/utils/strings.go
+++ b/utils/strings.go
@@ -40,7 +40,6 @@ func RemoveSpaces(input string) string {
 
 func StringToUint(input string) (uint, error) {
 	output, err := strconv.ParseUint(input, 10, 32)
-
 	if err != nil {
 		return 0, err
 	}
@@ -62,7 +61,17 @@ func StringToFileString(input string) string {
 	if input == "" {
 		return "unnamed-file"
 	}
-	return url.PathEscape(input)
+	return url.PathEscape(RemoveNonASCII(input))
+}
+
+func RemoveNonASCII(input string) string {
+	var result []rune
+	for _, r := range input {
+		if r <= 127 {
+			result = append(result, r)
+		}
+	}
+	return string(result)
 }
 
 func UintPtr(v uint) *uint {


### PR DESCRIPTION
- ensure that the public assets doc directory is created if not exists

- remove non ascii letters from slug and url path escape next to sanitize the URL to improve doc routing